### PR TITLE
feat(Server-side actions for created/updated by)

### DIFF
--- a/src/db/models/dishes/actions.ts
+++ b/src/db/models/dishes/actions.ts
@@ -38,7 +38,6 @@ export const Dishes: Actions = {
 		form.data.created_by_user_email = session?.user?.email;
 		form.data.date_added = new Date().toISOString();
 		form.data.date_updated = new Date().toISOString();
-		console.log('EVENT', event.locals.getSession);
 
 		// Add new _id to form data
 		const insert_data = prepare_data_for_insert<Dish>(form.data);

--- a/src/db/models/dishes/actions.ts
+++ b/src/db/models/dishes/actions.ts
@@ -19,15 +19,15 @@ import {
 	getSuccessMessage
 } from '$constants/forms';
 
-// TODO: Finish setting up validation so that we don't show success on empty form submissions
 export const Dishes: Actions = {
 	create: async function (event) {
-		// TODO: Auth Check for action
-		// if (!isAuthorized(event.locals.user)) return fail(403, { message: AUTH_ERROR_MESSAGE })
-
+		const session = await event.locals.getSession();
 		// Setup Form (remove _id from schema for validation)
 		const form = await superValidate(event, new_dish_schema);
-		console.log('POST', form);
+		// Check if session exists
+		if (!session) {
+			return message(form, AUTH_ERROR_MESSAGE);
+		}
 
 		// Check if form is valid
 		if (!form.valid) {
@@ -35,14 +35,17 @@ export const Dishes: Actions = {
 		}
 
 		// Add user form data server-side
+		form.data.created_by_user_email = session?.user?.email;
 		form.data.date_added = new Date().toISOString();
 		form.data.date_updated = new Date().toISOString();
+		console.log('EVENT', event.locals.getSession);
 
 		// Add new _id to form data
 		const insert_data = prepare_data_for_insert<Dish>(form.data);
 
 		// Insert into database
 		const created_path = <InsertOneResult>await dishes.insertOne(insert_data).catch(log_error);
+		console.log('FORM (create)', form);
 
 		// Redirect to _id page with a toast message
 		throw redirect(
@@ -60,8 +63,27 @@ export const Dishes: Actions = {
 
 	update: async function (event) {
 		// if (!isAuthorized(event.locals.user)) return fail(403, { message: AUTH_ERROR_MESSAGE })
-
+		const session = await event.locals.getSession();
 		const form = await superValidate(event, dishes_schema);
+
+		// Check if session exists
+		if (!session) {
+			return message(form, AUTH_ERROR_MESSAGE);
+		}
+
+		if (session?.user?.email !== form.data.created_by_user_email) {
+			throw redirect(
+				302,
+				`/authenticated/dishes/${form.data._id}`,
+				{
+					message: 'Cannot update this dish as it was not created by you.',
+					status: 'error',
+					// Add id so the toast gets assigned an id
+					id: uniqueId()
+				},
+				event
+			);
+		}
 
 		if (!form.valid) {
 			return message(form, CHECK_FORM_MESSAGE);
@@ -69,44 +91,45 @@ export const Dishes: Actions = {
 
 		// Update date_updated
 		form.data.date_updated = new Date().toISOString();
+		form.data.updated_by_user_email = session?.user?.email;
 
 		await dishes
 			.findOneAndUpdate({ _id: form.data._id }, { $set: form.data }, { returnDocument: 'after' })
 			.catch(log_error);
+		console.log('FORM (update)', form);
 
 		// Send a toast message along with form data
 		return message(form, getSuccessMessage('dish', 'updated'));
 	},
 
-	//TODO: Separate form action for ingredients
-	// updateIngredients: async function (event) {
-	// 	// if (!isAuthorized(event.locals.user)) return fail(403, { message: AUTH_ERROR_MESSAGE })
-
-	// 	const form = await superValidate(event, dishes_schema);
-
-	// 	if (!form.valid) {
-	// 		return message(form, CHECK_FORM_MESSAGE);
-	// 	}
-
-	// 	// Update date_updated
-	// 	form.data.date_updated = new Date().toISOString();
-
-	// 	await dishes
-	// 		.findOneAndUpdate({ _id: form.data._id }, { $set: form.data }, { returnDocument: 'after' })
-	// 		.catch(log_error);
-
-	// 	// Send a toast message along with form data
-	// 	return message(form, getSuccessMessage('dish', 'updated'));
-	// },
-
 	delete: async function (event) {
-		// if (!has_role(event.locals, 'admin')) return fail(401)
-
+		const session = await event.locals.getSession();
 		const form = await superValidate(event, dishes_schema);
+
+		// Check if session exists
+		if (!session) {
+			return message(form, AUTH_ERROR_MESSAGE);
+		}
+
+		// TODO: Setup a check so users can only delete their own dishes
+		// if (session?.user?.email !== form.data.created_by_user_email) {
+		// 	throw redirect(
+		// 		302,
+		// 		`/authenticated/dishes/${form.data._id}`,
+		// 		{
+		// 			message: `Cannot delete this dish as it was not created by you.`,
+		// 			status: 'error',
+		// 			// Add id so the toast gets assigned an id
+		// 			id: uniqueId()
+		// 		},
+		// 		event
+		// 	);
+		// }
 
 		if (!form.data._id) return fail(400, { message: DEFAULT_FORM_ERROR });
 
 		await dishes.deleteOne({ _id: form.data._id }).catch(log_error);
+		console.log('FORM (delete)', form);
 
 		throw redirect(
 			303,

--- a/src/db/models/dishes/schema.ts
+++ b/src/db/models/dishes/schema.ts
@@ -15,6 +15,8 @@ export const dishes_fields = {
 	serving_size: z.number().positive().max(9999).nullable().optional(),
 	prep_time: z.number().positive().max(9999).nullable().optional(),
 	cook_time: z.number().positive().max(9999).nullable().optional(),
+	created_by_user_email: z.string().email(),
+	updated_by_user_email: z.string().email(),
 	calories: z.number().positive().max(9999).nullable().optional(),
 	ingredients: z
 		.array(

--- a/src/lib/components/ConfirmDeleteButton.svelte
+++ b/src/lib/components/ConfirmDeleteButton.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import Modal from './Modal.svelte';
-	import Button from '$elements/Button.svelte';
 	import { superForm } from 'sveltekit-superforms/client';
 	import { getSuperOptions } from '$lib/forms/superforms';
 	import ConfirmDeleteModal from './ConfirmDeleteModal.svelte';

--- a/src/routes/authenticated/dishes/+page.server.ts
+++ b/src/routes/authenticated/dishes/+page.server.ts
@@ -1,7 +1,6 @@
 import type { Actions, PageServerLoad } from './$types';
 import { dishes } from '$db/models/dishes/collection';
 import { Dishes } from '$db/models/dishes/actions';
-import { fail } from '@sveltejs/kit';
 import { superValidate } from 'sveltekit-superforms/server';
 import { fix_pojo } from '$utilities/fix_pojo';
 import { new_dish_schema } from '$db/models/dishes/schema';

--- a/src/routes/authenticated/dishes/+page.svelte
+++ b/src/routes/authenticated/dishes/+page.svelte
@@ -6,6 +6,7 @@
 	import DebugSwitch from '$lib/components/DebugSwitch.svelte';
 
 	export let data: PageData;
+	$: ({ dishes } = data);
 
 	// Client API:
 	const { form, errors, constraints, enhance } = superForm(data.form, {
@@ -17,7 +18,6 @@
 		// This is a requirement when the schema contains nested objects:
 		dataType: 'json'
 	});
-	$: ({ dishes } = data);
 </script>
 
 <div class="flex justify-center items-center flex-col">

--- a/src/routes/authenticated/dishes/DishProfileForm.svelte
+++ b/src/routes/authenticated/dishes/DishProfileForm.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import DebugSwitch from '$lib/components/DebugSwitch.svelte';
-
 	export let form;
 	export let action: string;
 	export let errors;
@@ -8,8 +6,6 @@
 	export let enhance;
 	export let delayed = null;
 	export let submitText = 'submit';
-
-	let showDebug = false;
 </script>
 
 <form

--- a/src/routes/authenticated/dishes/[_id]/+page.svelte
+++ b/src/routes/authenticated/dishes/[_id]/+page.svelte
@@ -30,6 +30,7 @@
 		// This is a requirement when the schema contains nested objects:
 		dataType: 'json'
 	});
+	const userEmail = data.session?.user?.email;
 
 	function formatDate(dateString: string) {
 		const date = new Date(dateString);
@@ -39,6 +40,19 @@
 		 * @see https://date-fns.org/v2.30.0/docs/format
 		 */
 		return format(date, 'Pp');
+	}
+
+	// TODO: conditionally set "add" or "update" for button text
+	let updateButtonText = '';
+	let enableButton = false;
+
+	$: {
+		if (userEmail === dish?.created_by_user_email) {
+			updateButtonText = 'update';
+			enableButton = true;
+		} else {
+			enableButton = false;
+		}
 	}
 
 	$: ({ dish } = data);
@@ -72,27 +86,31 @@
 					<p>Cuisine: {dish.cuisine}</p>
 					<p>Added {formatDate(dish.date_added)}</p>
 					{#if dish?.date_updated !== dish?.date_added}
-						<p class="text-secondary">
+						<p class="text-accent text-xs">
 							*Updated {formatDate(dish.date_updated)}
 						</p>
 					{/if}
 					<div class="flex justify-between">
 						<form>
 							<div class="flex justify-between">
-								<button
-									on:click={() => (activeModalId = 'profile')}
-									type="button"
-									class="btn btn-sm btn-primary"
-								>
-									Update</button
-								>
+								{#if enableButton}
+									<button
+										on:click={() => (activeModalId = 'profile')}
+										type="button"
+										class="btn btn-sm btn-primary"
+									>
+										{updateButtonText}</button
+									>
+								{/if}
 							</div>
 						</form>
-						<ConfirmDeleteButton
-							description="Are you sure you want to delete {dish.name}?"
-							action="?/delete"
-							_id={$form._id}>Delete</ConfirmDeleteButton
-						>
+						{#if enableButton}
+							<ConfirmDeleteButton
+								description="Are you sure you want to delete {dish.name}?"
+								action="?/delete"
+								_id={$form._id}>Delete</ConfirmDeleteButton
+							>
+						{/if}
 					</div>
 				</div>
 			</div>
@@ -132,17 +150,15 @@
 					</div>
 
 					<div class="flex justify-between">
-						<button
-							on:click={() => (activeModalId = 'numbers')}
-							type="button"
-							class="btn btn-sm btn-primary"
-						>
-							{#if dish?.prep_time && dish?.cook_time && dish?.calories}
-								Update
-							{:else}
-								Add
-							{/if}
-						</button>
+						{#if enableButton}
+							<button
+								on:click={() => (activeModalId = 'numbers')}
+								type="button"
+								class="btn btn-sm btn-primary"
+							>
+								{updateButtonText}
+							</button>
+						{/if}
 					</div>
 				</div>
 			</div>
@@ -160,17 +176,15 @@
 						<EmptyState content="There are no ingredients." />
 					{/if}
 					<div class="flex justify-between">
-						<button
-							on:click={() => (activeModalId = 'ingredients')}
-							type="button"
-							class="btn btn-sm btn-primary"
-						>
-							{#if dish?.ingredients?.length > 0}
-								Update
-							{:else}
-								Add
-							{/if}
-						</button>
+						{#if enableButton}
+							<button
+								on:click={() => (activeModalId = 'numbers')}
+								type="button"
+								class="btn btn-sm btn-primary"
+							>
+								{updateButtonText}
+							</button>
+						{/if}
 					</div>
 				</div>
 			</div>
@@ -191,17 +205,15 @@
 					<EmptyState content="There are no notes." />
 				{/if}
 				<div class="flex justify-between">
-					<button
-						on:click={() => (activeModalId = 'notes')}
-						type="button"
-						class="btn btn-sm btn-primary"
-					>
-						{#if dish?.ingredients?.length > 0 && dish?.notes?.length > 0}
-							Update
-						{:else}
-							Add
-						{/if}
-					</button>
+					{#if enableButton}
+						<button
+							on:click={() => (activeModalId = 'numbers')}
+							type="button"
+							class="btn btn-sm btn-primary"
+						>
+							{updateButtonText}
+						</button>
+					{/if}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### Summary:

- Schema updates; UI conditional rendering; server-side action updates.

### Details:

- Added server-side check for update action that allows users to update dishes only if their email matches the email for `created_by_user_email`
- Server-side check for actions if session is truthy, otherwise action returns `AUTH_ERROR_MESSAGE`
- `created_by_user_email` and `updated_by_user_email` are set in `create` and `update` server actions
- Added conditional rendering on Update and Delete buttons on [_id] page so that they are only visible if the session email is the same as the `created_by_user_email` of the dish.