### PR TITLE
feat(Misc Form and Page Updates)

### DIFF
--- a/src/lib/components/LoginButton.svelte
+++ b/src/lib/components/LoginButton.svelte
@@ -48,7 +48,7 @@
 			our platform.
 		</p>
 		<div class="form-control py-5">
-			<label class="cursor-pointer label flex flex-row items-center justify-start gap-x-24">
+			<label class="cursor-pointer label flex flex-row justify-center gap-x-10">
 				<span class="label-text text-accent">I Agree</span>
 				<input
 					type="checkbox"
@@ -58,20 +58,27 @@
 			</label>
 		</div>
 
-		<button
-			class="btn btn-sm btn-secondary"
-			on:click|preventDefault={() => {
-				isConfirmActive = false;
-			}}
-		>
-			Decline
-		</button>
-		<!-- 
-				 preventDefault is a Svelte modifier which calls event.preventDefault() before running the handler. In this case, it will prevent the form from being submitted when you click the "Cancel" button, thus preventing the dish from being deleted.
-				 @see docs https://svelte.dev/tutorial/event-modifiers
-			-->
-		<button type="submit" class="btn btn-sm btn-error" {disabled} on:click={() => signIn('github')}>
-			Accept
-		</button>
+		<div class="flex flex-row justify-center gap-x-2">
+			<button
+				class="btn btn-sm btn-secondary"
+				on:click|preventDefault={() => {
+					isConfirmActive = false;
+				}}
+			>
+				Decline
+			</button>
+			<!-- 
+					 preventDefault is a Svelte modifier which calls event.preventDefault() before running the handler. In this case, it will prevent the form from being submitted when you click the "Cancel" button, thus preventing the dish from being deleted.
+					 @see docs https://svelte.dev/tutorial/event-modifiers
+				-->
+			<button
+				type="submit"
+				class="btn btn-sm btn-error"
+				{disabled}
+				on:click={() => signIn('github')}
+			>
+				Accept
+			</button>
+		</div>
 	</div>
 </ConfirmDeleteModal>

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -1,11 +1,7 @@
-<script>
-	let currentYear = new Date().getFullYear();
-</script>
-
 <footer class="footer footer-center text-base-content bottom-0 absolute">
 	<div>
 		<p class="py-3">
-			© {currentYear}
+			© {new Date().getFullYear()}
 			<a
 				rel="noreferrer noopener"
 				class="no-underline link link-secondary"

--- a/src/routes/authenticated/dishes/+page.server.ts
+++ b/src/routes/authenticated/dishes/+page.server.ts
@@ -1,4 +1,4 @@
-import type { Actions, PageServerLoad } from './$types';
+import type { PageServerLoad } from './$types';
 import { dishes } from '$db/models/dishes/collection';
 import { Dishes } from '$db/models/dishes/actions';
 import { superValidate } from 'sveltekit-superforms/server';
@@ -6,7 +6,13 @@ import { fix_pojo } from '$utilities/fix_pojo';
 import { new_dish_schema } from '$db/models/dishes/schema';
 
 export const load = (async (event) => {
-	const all_dishes = await dishes.find({}, { sort: { order: 1 } }).toArray();
+	const session = await event.locals.getSession();
+	const user_email = session?.user?.email;
+
+	// Query ONLY for dishes made by the user (same email)
+	const all_user_dishes = await dishes
+		.find({ created_by_user_email: user_email }, { sort: { order: 1 } })
+		.toArray();
 	// Server API:
 	// See https://zod.dev/?id=primitives for schema syntax
 	const form = await superValidate(event, new_dish_schema);
@@ -14,7 +20,7 @@ export const load = (async (event) => {
 	// Always return { form } in load and form actions.
 	return {
 		form,
-		dishes: fix_pojo(all_dishes)
+		dishes: fix_pojo(all_user_dishes)
 	};
 }) satisfies PageServerLoad;
 

--- a/src/routes/authenticated/dishes/+page.svelte
+++ b/src/routes/authenticated/dishes/+page.svelte
@@ -29,13 +29,27 @@
 
 <DebugSwitch form={$form} />
 
-<h2 class="text-2xl text-primary my-2">Dishes:</h2>
+<h2 class="text-2xl text-primary my-2">My Dishes:</h2>
 {#each dishes as dish}
 	<div class="my-4 card w-80 bg-base-300 shadow-xl text-primary self-center">
 		<div class="card-body">
 			<h3 class="card-title">{dish.name}</h3>
+			<p class="text-sm text-secondary">{dish.cuisine}</p>
+			<div class="rating">
+				{#each Array.from({ length: Number(dish.rating) }).map((_, i) => i + 1) || [] as rating}
+					<input
+						type="radio"
+						id={`rating_${rating}`}
+						name="rating"
+						value={rating}
+						checked={Number(dish.rating) === rating}
+						disabled
+						class="mask mask-star-2 bg-orange-400 cursor-default"
+					/>
+				{/each}
+			</div>
 			<div class="card-actions justify-end">
-				<a href="/authenticated/dishes/{dish?._id}" class="btn btn-primary">View</a>
+				<a href="/authenticated/dishes/{dish?._id}" class="btn btn-secondary">View</a>
 			</div>
 		</div>
 	</div>

--- a/src/routes/authenticated/dishes/DishIngredientsForm.svelte
+++ b/src/routes/authenticated/dishes/DishIngredientsForm.svelte
@@ -39,8 +39,9 @@
 			placeholder="Add ingredients"
 			bind:value={newIngredient}
 		/>
-		<button on:click|preventDefault={addIngredient} class="btn-primary btn py-1 px-2 mt-2"
-			>Add</button
+		<button
+			on:click|preventDefault={addIngredient}
+			class="btn btn-sm btn-secondary btn-outline py-1 px-2 mt-2">Add</button
 		>
 		<div>
 			{#each $form?.ingredients || [] as ingredient, index}
@@ -63,9 +64,5 @@
 			>{/if}
 	</div>
 
-	<button
-		type="submit"
-		class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-		>{submitText}</button
-	>
+	<button type="submit" class="btn btn-sm btn-primary">{submitText}</button>
 </form>

--- a/src/routes/authenticated/dishes/DishNotesForm.svelte
+++ b/src/routes/authenticated/dishes/DishNotesForm.svelte
@@ -4,7 +4,7 @@
 	export let errors;
 	export let constraints;
 	export let enhance;
-	export let submitText = 'submit';
+	export let submitText = 'update';
 </script>
 
 <form
@@ -16,7 +16,7 @@
 	<div class="mb-4">
 		<label class="block text-primary text-sm font-bold mb-2" for="instructions">Instructions</label>
 		<textarea
-			class="textarea textarea-bordered textarea-md w-full"
+			class="textarea textarea-bordered textarea-md w-full h-72"
 			placeholder="Instructions"
 			name="instructions"
 			data-invalid={$errors.instructions}
@@ -27,7 +27,7 @@
 	<div class="mb-4">
 		<label class="block text-primary text-sm font-bold mb-2" for="notes">Notes</label>
 		<textarea
-			class="textarea textarea-bordered textarea-md w-full"
+			class="textarea textarea-bordered textarea-md w-full h-72"
 			placeholder="Additional notes"
 			name="notes"
 			data-invalid={$errors.notes}
@@ -35,9 +35,5 @@
 			{...$constraints.notes}
 		/>
 	</div>
-	<button
-		type="submit"
-		class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-		>{submitText}</button
-	>
+	<button type="submit" class="btn btn-sm btn-primary">{submitText}</button>
 </form>

--- a/src/routes/authenticated/dishes/DishNumbersForm.svelte
+++ b/src/routes/authenticated/dishes/DishNumbersForm.svelte
@@ -4,7 +4,7 @@
 	export let errors;
 	export let constraints;
 	export let enhance;
-	export let submitText = 'submit';
+	export let submitText = 'update';
 </script>
 
 <form
@@ -76,10 +76,7 @@
 	{/if}
 
 	<br />
-	<button
-		type="submit"
-		class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-	>
+	<button type="submit" class="btn btn-sm btn-primary">
 		{submitText}
 	</button>
 </form>

--- a/src/routes/authenticated/dishes/DishProfileForm.svelte
+++ b/src/routes/authenticated/dishes/DishProfileForm.svelte
@@ -84,10 +84,6 @@
 			{...$constraints.cuisine}
 		/>
 	</div>
-	<button
-		type="submit"
-		class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-		>{submitText}</button
-	>
+	<button type="submit" class="btn btn-sm btn-primary">{submitText}</button>
 	{#if $delayed}<span class="delayed">Working...</span>{/if}
 </form>


### PR DESCRIPTION
### Caution!

Please note that there are limitations to grabbing just dishes where the `created_by_user_email` matches the session email! If the user ever changes their email, the query will NOT pull up dishes made from the previous email(s). A better way to do this would be to use a unique id for that user, however nothing is setup to create this. Also, since OAuth is setup just for GitHub, the session object from GitHub doesn't provide a unique user id.

### Summary:

Updated forms and info on card for dishes

### Details:

- Changed MongoDB query to only grab dishes created by the email that matches the user's email.
- Added additional information on dishes card(s) on /dishes
- Changed styling on buttons (and more)